### PR TITLE
Comply to requirement of plex_rcs rclone log for faster plex library refresh when using remote feeder

### DIFF
--- a/mounts/crypt.service
+++ b/mounts/crypt.service
@@ -22,7 +22,7 @@ ExecStart=/usr/bin/rclone mount {{drive}}: /mnt/{{drive}} \
 --uid=1000 --gid=1000 \
 --umask 002 \
 --log-file=/var/plexguide/logs/rclone-{{drive}}.log \
---log-level ERROR \
+--log-level INFO \
 --timeout 1h \
 --vfs-cache-mode writes \
 --dir-cache-time {{vfs_dct}}m \

--- a/mounts/drive.service
+++ b/mounts/drive.service
@@ -22,7 +22,7 @@ ExecStart=/usr/bin/rclone mount {{drive}}: /mnt/{{drive}} \
 --uid=1000 --gid=1000 \
 --umask 002 \
 --log-file=/var/plexguide/logs/rclone-{{drive}}.log \
---log-level ERROR \
+--log-level INFO \
 --timeout 1h \
 --dir-cache-time {{vfs_dct}}m \
 --vfs-cache-max-age {{vfs_cma}}h \


### PR DESCRIPTION
[plex_rcs](https://github.com/stokkes/plex_rcs) requires rclone log INFO log level to be able to read the cache expiration and trigger Plex library scan.

This is very useful for users who use remote feeder (GC Instance) and their Plex server is unable to scan/add the newly download contents. Remote Sonarr/Radarr "Connect: Plex Media Server" won't work as the local server mount uses rclone mount cache.