### PR TITLE
Version changed from 1.47 to 1.47.0

### DIFF
--- a/roles/rcloneinstall/defaults/main.yml
+++ b/roles/rcloneinstall/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 #rclone version can be defined as a release number or as beta
-rclone_version: "1.47"
+rclone_version: "1.47.0"
 
 # Defaults in case no variables for OS are chosen
 PACKAGES:


### PR DESCRIPTION
The guys from rclone changed how they name the updates specifically on the 1.47 release:
https://github.com/ncw/rclone/releases