### PR TITLE
Inconsistent usage of clone.password/clone.salt vs pgclone.password/pgclone.salt

### DIFF
--- a/functions/passwords.sh
+++ b/functions/passwords.sh
@@ -8,8 +8,8 @@
 blitzpasswordmain () {
 pgclonevars
 
-clonepassword57=$(cat /var/plexguide/clone.password)
-clonesalt57=$(cat /var/plexguide/clone.salt)
+clonepassword57=$(cat /var/plexguide/pgclone.password)
+clonesalt57=$(cat /var/plexguide/pgclone.salt)
 
 if [[ "$pstatus" != "NOT-SET" ]]; then
 tee <<-EOF
@@ -37,8 +37,8 @@ EOF
 read -p '↘️  Input Value | Press [Enter]: ' typed < /dev/tty
 case $typed in
 2 )
-    rm -rf /var/plexguide/clone.password 1>/dev/null 2>&1
-    rm -rf /var/plexguide/clone.salt 1>/dev/null 2>&1
+    rm -rf /var/plexguide/pgclone.password 1>/dev/null 2>&1
+    rm -rf /var/plexguide/pgclone.salt 1>/dev/null 2>&1
 
     rm -rf /opt/appdata/plexguide/.gcrypt 1>/dev/null 2>&1
     rm -rf /opt/appdata/plexguide/.gdrive 1>/dev/null 2>&1
@@ -118,8 +118,8 @@ read -p '↘️  Type y or n | Press [ENTER]: ' typed < /dev/tty
 
 if [[ "$typed" == "n" ]]; then blitzpasswordmain;
 elif [[ "$typed" == "y" ]]; then
-echo $primarypassword > /var/plexguide/clone.password
-echo $secondarypassword > /var/plexguide/clone.salt
+echo $primarypassword > /var/plexguide/pgclone.password
+echo $secondarypassword > /var/plexguide/pgclone.salt
 else blitzpasswordfinal; fi
 
 tee <<-EOF

--- a/functions/variables.sh
+++ b/functions/variables.sh
@@ -27,11 +27,11 @@ pgclonevars () {
   variable /var/plexguide/oauth.check ""
   oauthcheck=$(cat /var/plexguide/oauth.check)
 
-  variable /var/plexguide/clone.password "NOT-SET"
-  if [[ $(cat /var/plexguide/clone.password) == "NOT-SET" ]]; then pstatus="NOT-SET"
+  variable /var/plexguide/pgclone.password "NOT-SET"
+  if [[ $(cat /var/plexguide/pgclone.password) == "NOT-SET" ]]; then pstatus="NOT-SET"
   else
     pstatus="ACTIVE"
-    clonepassword=$(cat /var/plexguide/clone.password)
+    clonepassword=$(cat /var/plexguide/pgclone.password)
     clonesalt=$(cat /var/plexguide/pgclone.salt)
   fi
 


### PR DESCRIPTION
Running through the install it creates the proper passwords in clone.password and clone.salt and leaves pgclone.password and pgclone.salt blank. Whereas keys.sh looks for pgclone.* to generate the rclone.conf. Thus having rclone obscuring an empty file causing encryption not to work.