### PR TITLE
Add vfs-cache-max-size and vfs-cache-mode

### DIFF
--- a/functions/mountnumbers.sh
+++ b/functions/mountnumbers.sh
@@ -69,8 +69,7 @@ mountset () {
         sizeSuffix="MB"
         start="8"
         end="1024"
-        note="
-        Open files will be buffered to RAM up to this limit. This limit is per opened file.
+        note="Open files will be buffered to RAM up to this limit. This limit is per opened file.
         
         The buffer size should be a relatively small amount. It's intended to smooth out network congestion and blips.
         The buffer will get cleared when you seek in plex or when the file is closed.
@@ -128,29 +127,31 @@ mountset () {
         sizeSuffix=""
         start="1"
         end="4"
-        note="
-        1) off:
-          - Files opened for read OR write will NOT be buffered to disks.
-          - Files can’t be opened for both read AND write.
-          - Files opened for write can’t be seeked.
-        2) minimal:
-          - Files opened for read/write will be buffered to disks.
-          - Files opened for write only can’t be seeked
-        3) writes: 
-          - Write only and read/write files are buffered to disk first.
-          - This mode should support all normal file system operations.
-        4) full: 
-          - All files are buffered to and from disk. 
-          - When a file is opened for read it will be downloaded in its entirety first.
-          - This mode should support all normal file system operations."
-fi
+        note="1) off:
+            - Files opened for read OR write will NOT be buffered to disks.
+            - Files can’t be opened for both read AND write.
+            - Files opened for write can’t be seeked.
+            
+            2) minimal:
+                - Files opened for read/write will be buffered to disks.
+                - Files opened for write only can’t be seeked
+              
+            3) writes: 
+                - Write only and read/write files are buffered to disk first.
+                - This mode should support all normal file system operations.
+
+            4) full: 
+                - All files are buffered to and from disk. 
+                - When a file is opened for read it will be downloaded in its entirety first.
+                - This mode should support all normal file system operations."
+  fi
 
 if [[ "$mountselection" == "7" ]]; then
   name="VFS-Cache-Max-Age"
   sizeSuffix="Hours"
   start="1"
   end="360"
-  note="Only used if vfs-cache-mode is NOT off, impacts how long files are cached in memory!"
+  note="Impacts how long files are cached on disk, only used if vfs-cache-mode is NOT off!"
 fi
 
 if [[ "$mountselection" == "8" ]]; then
@@ -158,7 +159,7 @@ if [[ "$mountselection" == "8" ]]; then
   sizeSuffix="GB"
   start="1"
   end="1000"
-  note="Only used if vfs-cache-mode is NOT off, impacts how long files are cached on disk. Value is the max total size of objects in the cache."
+  note="The max total size of objects in the cache, only used if vfs-cache-mode is NOT off."
 fi
     
 tee <<-EOF

--- a/functions/mountnumbers.sh
+++ b/functions/mountnumbers.sh
@@ -17,7 +17,7 @@ VFS RClone Mount Settings ~ vfs.pgblitz.com
 RClone Variable Name           Default ~ Current Settings
 
 [1] Buffer-Size                16MB        [$vfs_bs] MB
-[2] Drive-Chunk-Size           256MB       [$vfs_dcs] MB
+[2] Drive-Chunk-Size           64MB       [$vfs_dcs] MB
 [3] Dir-Cache-Time             2M          [$vfs_dct] Minutes
 [4] VFS-Read-Chunk-Size        64MB        [$vfs_rcs] MB
 [5] VFS-Read-Chunk-Size-Limit  2GB         [$vfs_rcsl] GB

--- a/functions/mountnumbers.sh
+++ b/functions/mountnumbers.sh
@@ -79,9 +79,8 @@ mountset () {
         Plex opens several files during library scans and each file open will consume up to the amount of RAM specified.
         If you set this too high and don't have enough free RAM, you will cause the mounts to crash!
         
-        Recommendations: 2GB RAM: 8MB | 4GB RAM: 16MB | 8GB RAM: 16-32MB | 16GB+ RAM: 64MB-128MB
-        
-        NOTICE: This value must be less than the vfs-read-chunk-size to prevent 'too many open file requests' errors!
+        RECOMMENDATIONS: 2GB RAM: 8MB | 4GB RAM: 16MB | 8GB RAM: 16-32MB | 16GB+ RAM: 64MB-128MB
+        This value must be less than the vfs-read-chunk-size to prevent 'too many open file requests' errors!
         "
 
     fi
@@ -111,7 +110,8 @@ mountset () {
         sizeSuffix="MB"
         start="16"
         end="1024"
-        note="Must be greater than the buffer-size to prevent too many open file requests!"
+        note="This allows reading the source objects in parts, by requesting only chunks from the remote that are actually read at the cost of an increased number of requests.
+        Must be greater than the buffer-size to prevent too many open file requests!"
     fi
     
     if [[ "$mountselection" == "5" ]]; then
@@ -119,7 +119,8 @@ mountset () {
         sizeSuffix="GB"
         start="1"
         end="100"
-        note="The chunk size for each open file will get doubled for each chunk read, until this limit is reached."
+        note="The chunk size for each open file will get doubled for each chunk read, until the specified value is reached.
+        This limit must be greater than vfs-read-chunk-size and it's only used when the vfs-cache-mode is not set to full."
     fi
     
     if [[ "$mountselection" == "6" ]]; then
@@ -128,22 +129,22 @@ mountset () {
         start="1"
         end="4"
         note="1) off:
-    - Files opened for read OR write will NOT be buffered to disks.
-    - Files can’t be opened for both read AND write.
-    - Files opened for write can’t be seeked.
+    ◽️ Files opened for read OR write will NOT be buffered to disks.
+    ◽️ Files can’t be opened for both read AND write.
+    ◽️ Files opened for write can’t be seeked.
 
 2) minimal:
-    - Files opened for read/write will be buffered to disks.
-    - Files opened for write only can’t be seeked
+    ◽️ Files opened for read/write will be buffered to disks.
+    ◽️ Files opened for write only can’t be seeked
 
 3) writes: 
-    - Write only and read/write files are buffered to disk first.
-    - This mode should support all normal file system operations.
+    ◽️ Write only and read/write files are buffered to disk first.
+    ◽️ This mode should support all normal file system operations.
 
 4) full: 
-    - All files are buffered to and from disk. 
-    - When a file is opened for read it will be downloaded in its entirety first.
-    - This mode should support all normal file system operations."
+    ◽️ All files are buffered to and from disk. 
+    ◽️ When a file is opened for read it will be downloaded in its entirety first.
+    ◽️ This mode should support all normal file system operations."
 fi
 
 if [[ "$mountselection" == "7" ]]; then

--- a/functions/mountnumbers.sh
+++ b/functions/mountnumbers.sh
@@ -16,19 +16,18 @@ VFS RClone Mount Settings ~ vfs.pgblitz.com
 
 RClone Variable Name           Default ~ Current Settings
 
-[1] Buffer-Size                16MB        [$vfs_bs] MB
-[2] Drive-Chunk-Size           64MB       [$vfs_dcs] MB
-[3] Dir-Cache-Time             2M          [$vfs_dct] Minutes
-[4] VFS-Read-Chunk-Size        64MB        [$vfs_rcs] MB
-[5] VFS-Read-Chunk-Size-Limit  2GB         [$vfs_rcsl] GB
-[6] VFS-Cache-Mode             off         [$vfs_cm]
-[7] VFS-Cache-Max-Age          168H        [$vfs_cma] Hours
-[8] VFS-Cache-Max-Size         100GB       [$vfs_cms] GB
+[1] Buffer-Size                16M        [$vfs_bs] MB
+[2] Drive-Chunk-Size           64M        [$vfs_dcs] MB
+[3] Dir-Cache-Time             2M         [$vfs_dct] Minutes
+[4] VFS-Read-Chunk-Size        64M        [$vfs_rcs] MB
+[5] VFS-Read-Chunk-Size-Limit  2G         [$vfs_rcsl] GB
+[6] VFS-Cache-Mode             off        [$vfs_cm]
+[7] VFS-Cache-Max-Age          168H       [$vfs_cma] Hours
+[8] VFS-Cache-Max-Size         100G       [$vfs_cms] GB
 [Z] Exit
 
-note: Visit the URL! Bad settings causes mount performance issues!
-NOTE2: Changed the Vaules? Must REDEPLOY to go into AFFECT!
-
+Please read the wiki on how changing these settings impact stability and performance!
+After you change these settings, you must redeploy the mounts for them to take effect.
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 EOF
     
@@ -86,17 +85,16 @@ mountset () {
         NOTICE: This value must be less than the vfs-read-chunk-size to prevent 'too many open file requests' errors!
         "
 
-fi
+    fi
 
-if [[ "$mountselection" == "2" ]]; then
-  name="Drive-Chunk-Size"
-  sizeSuffix="MB"
-  start="8"
-  end="1024"
-        note="
-        Upload chunk size, increasing the chunk size may increase upload speed, however it can result it mor
-        Input must be one of the following numbers (power of 2)!
-        [8] [16] [32] [64] [128] [256] [512] [1024]"
+    if [[ "$mountselection" == "2" ]]; then
+      name="Drive-Chunk-Size"
+      sizeSuffix="MB"
+      start="8"
+      end="1024"
+      note="Upload chunk size, increasing the chunk size may increase upload speed, however it can result it mor
+            Input must be one of the following numbers (power of 2)!
+            [8] [16] [32] [64] [128] [256] [512] [1024]"
     fi
     
     if [[ "$mountselection" == "3" ]]; then
@@ -144,8 +142,7 @@ if [[ "$mountselection" == "2" ]]; then
         4) full: 
           - All files are buffered to and from disk. 
           - When a file is opened for read it will be downloaded in its entirety first.
-          - This mode should support all normal file system operations.
-"
+          - This mode should support all normal file system operations."
 fi
 
 if [[ "$mountselection" == "7" ]]; then
@@ -170,10 +167,7 @@ tee <<-EOF
 Setting Variable >>> $name
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-Type a number between [$start] and [$end] ($sizeSuffix)
-
-Please read the wiki on how changing these settings impact stability and performance!
-After you change these settings, you must redeploy the mounts for them to take effect.
+Type a number between [$start] and [$end] $sizeSuffix
 
 $note
 

--- a/functions/mountnumbers.sh
+++ b/functions/mountnumbers.sh
@@ -91,9 +91,9 @@ mountset () {
       sizeSuffix="MB"
       start="8"
       end="1024"
-      note="Upload chunk size, increasing the chunk size may increase upload speed, however it can result it mor
-            Input must be one of the following numbers (power of 2)!
-            [8] [16] [32] [64] [128] [256] [512] [1024]"
+      note="Upload chunk size, increasing the chunk size may increase upload speed, however it uses more RAM.
+      Input must be one of the following numbers (power of 2)!
+      [8] [16] [32] [64] [128] [256] [512] [1024]"
     fi
     
     if [[ "$mountselection" == "3" ]]; then
@@ -128,23 +128,23 @@ mountset () {
         start="1"
         end="4"
         note="1) off:
-            - Files opened for read OR write will NOT be buffered to disks.
-            - Files can’t be opened for both read AND write.
-            - Files opened for write can’t be seeked.
-            
-            2) minimal:
-                - Files opened for read/write will be buffered to disks.
-                - Files opened for write only can’t be seeked
-              
-            3) writes: 
-                - Write only and read/write files are buffered to disk first.
-                - This mode should support all normal file system operations.
+    - Files opened for read OR write will NOT be buffered to disks.
+    - Files can’t be opened for both read AND write.
+    - Files opened for write can’t be seeked.
 
-            4) full: 
-                - All files are buffered to and from disk. 
-                - When a file is opened for read it will be downloaded in its entirety first.
-                - This mode should support all normal file system operations."
-  fi
+2) minimal:
+    - Files opened for read/write will be buffered to disks.
+    - Files opened for write only can’t be seeked
+
+3) writes: 
+    - Write only and read/write files are buffered to disk first.
+    - This mode should support all normal file system operations.
+
+4) full: 
+    - All files are buffered to and from disk. 
+    - When a file is opened for read it will be downloaded in its entirety first.
+    - This mode should support all normal file system operations."
+fi
 
 if [[ "$mountselection" == "7" ]]; then
   name="VFS-Cache-Max-Age"

--- a/functions/mountnumbers.sh
+++ b/functions/mountnumbers.sh
@@ -6,8 +6,8 @@
 # GNU:        General Public License v3.0
 ################################################################################
 mountnumbers () {
-pgclonevars
-
+    pgclonevars
+    
 tee <<-EOF
 
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
@@ -16,163 +16,212 @@ VFS RClone Mount Settings ~ vfs.pgblitz.com
 
 RClone Variable Name           Default ~ Current Settings
 
-[1] Buffer-Size                32        [$vfs_bs] MB
-[2] Drive-Chunk-Size           32        [$vfs_dcs] MB
+[1] Buffer-Size                16        [$vfs_bs] MB
+[2] Drive-Chunk-Size           256        [$vfs_dcs] MB
 [3] Dir-Cache-Time             2         [$vfs_dct] Minutes
-[4] VFS-Cache-Max-Age          72        [$vfs_cma] Hours
-[5] VFS-Read-Chunk-Size        64        [$vfs_rcs] MB
-[6] VFS-Read-Chunk-Size-Limit  2         [$vfs_rcsl] GB
+[4] VFS-Read-Chunk-Size        64        [$vfs_rcs] MB
+[5] VFS-Read-Chunk-Size-Limit  2         [$vfs_rcsl] GB
+[6] VFS-Cache-Mode             off       [$vfs_cm]
+[7] VFS-Cache-Max-Age          72        [$vfs_cma] Hours
+[8] VFS-Cache-Max-Size         250        [$vfs_cms] GB
 [Z] Exit
 
-NOTE1: Visit the URL! Bad settings causes mount performance issues!
+note: Visit the URL! Bad settings causes mount performance issues!
 NOTE2: Changed the Vaules? Must REDEPLOY to go into AFFECT!
 
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 EOF
-
-read -rp '↘️  Input Selection | Press [ENTER]: ' fluffycat < /dev/tty
-
-case $fluffycat in
-    1 )
+    
+    read -rp '↘️  Input Selection | Press [ENTER]: ' fluffycat < /dev/tty
+    
+    case $fluffycat in
+        1 )
         mountset ;;
-    2 )
+        2 )
         mountset ;;
-    3 )
+        3 )
         mountset ;;
-    4 )
+        4 )
         mountset ;;
-    5 )
+        5 )
         mountset ;;
-    6 )
+        6 )
         mountset ;;
-    z )
+        7 )
+        mountset ;;
+        8 )
+        mountset ;;
+        z )
         a=b ;;
-    Z )
+        Z )
         a=b ;;
-    * )
+        * )
         mountnumbers ;;
-  esac
-
+    esac
+    
 }
 
 mountset () {
-
-mountselection="$fluffycat"
-
-if [[ "$mountselection" == "1" ]]; then
-  name="Buffer-Size"
-  endinfo="MB"
-  start1="8"
-  end1="1024"
-  note1="
-NOTE2: Utilizes RAM for each deployed stream. Increasing the size improves
-the load time/performance; but if the server runs out of RAM due to the
-settings being too high, the mounts can crash and dismount!
-
-NOTE3: Must be less than the vfs-read-chunk-size to prevent too many open file requests!"
+    
+    mountselection="$fluffycat"
+    
+    if [[ "$mountselection" == "1" ]]; then
+        name="Buffer-Size"
+        sizeSuffix="MB"
+        start="8"
+        end="1024"
+        note="
+        Open files will be buffered to RAM up to this limit. This limit is per opened file.
+        
+        The buffer size should be a relatively small amount. It's intended to smooth out network congestion and blips.
+        The buffer will get cleared when you seek in plex or when the file is closed.
+        Having a larger buffer may cause slower video start times.
+        
+        WARNING: This is highly dependent on the amount of RAM and number of opened files.
+        Plex opens several files during library scans and each file open will consume up to the amount of RAM specified.
+        If you set this too high and don't have enough free RAM, you will cause the mounts to crash!
+        
+        Recommendations: 2GB RAM: 8MB | 4GB RAM: 16MB | 8GB RAM: 16-32MB | 16GB+ RAM: 64MB-128MB
+        
+        NOTICE: This value must be less than the vfs-read-chunk-size to prevent 'too many open file requests' errors!
+        "
 
 fi
 
 if [[ "$mountselection" == "2" ]]; then
   name="Drive-Chunk-Size"
-  endinfo="MB"
-  start1="8"
-  end1="1024"
-  note1="
-NOTE2: Upload chunk size, only impacts uploading, not recommended to change!
-
-NOTE3: Input must be one of the following numbers below (power of 2)!
-[8] [16] [32] [64] [128] [256] [512] [1024]"
+  sizeSuffix="MB"
+  start="8"
+  end="1024"
+        note="
+        Upload chunk size, increasing the chunk size may increase upload speed, however it can result it mor
+        Input must be one of the following numbers (power of 2)!
+        [8] [16] [32] [64] [128] [256] [512] [1024]"
+    fi
+    
+    if [[ "$mountselection" == "3" ]]; then
+        name="Dir-Cache-Time"
+        sizeSuffix="Minutes"
+        start="1"
+        end="7620"
+        note="This controls the cache time for remote directory information and contents.
+        This may delay external changes (such as from gdrive website) from being seen on your server until the cache expires.
+        You should set this high unless you make lots of external changes."
+    fi
+    
+    if [[ "$mountselection" == "4" ]]; then
+        name="VFS-Read-Chunk-Size"
+        sizeSuffix="MB"
+        start="16"
+        end="1024"
+        note="Must be greater than the buffer-size to prevent too many open file requests!"
+    fi
+    
+    if [[ "$mountselection" == "5" ]]; then
+        name="VFS-Read-Chunk-Size-Limit"
+        sizeSuffix="GB"
+        start="1"
+        end="100"
+        note="The chunk size for each open file will get doubled for each chunk read, until this limit is reached."
+    fi
+    
+    if [[ "$mountselection" == "6" ]]; then
+        name="VFS-Cache-Mode"
+        sizeSuffix=""
+        start="1"
+        end="4"
+        note="
+        1) off:
+          - Files opened for read OR write will NOT be buffered to disks.
+          - Files can’t be opened for both read AND write.
+          - Files opened for write can’t be seeked.
+        2) minimal:
+          - Files opened for read/write will be buffered to disks.
+          - Files opened for write only can’t be seeked
+        3) writes: 
+          - Write only and read/write files are buffered to disk first.
+          - This mode should support all normal file system operations.
+        4) full: 
+          - All files are buffered to and from disk. 
+          - When a file is opened for read it will be downloaded in its entirety first.
+          - This mode should support all normal file system operations.
+"
 fi
 
-if [[ "$mountselection" == "3" ]]; then
-  name="Dir-Cache-Time"
-  endinfo="Minutes"
-  start1="1"
-  end1="1024"
-  note1="
-NOTE2: This controls the cache time for directory information and contents. 
-Local changes on the server are not impacted. 
-However, this does impact remote changes (such as from gdrive website)! 
-This can delay external changes from being seen until the cache expires.
-You should set this high if you don't regulary add/modify files outside of your server."
-fi
-
-if [[ "$mountselection" == "4" ]]; then
+if [[ "$mountselection" == "7" ]]; then
   name="VFS-Cache-Max-Age"
-  endinfo="Hours"
-  start1="1"
-  end1="96"
-  note1="
-NOTE2: Impacts how long a directory is cached in memory!"
+  sizeSuffix="Hours"
+  start="1"
+  end="360"
+  note="Only used if vfs-cache-mode is NOT off, impacts how long files are cached in memory!"
 fi
 
-if [[ "$mountselection" == "5" ]]; then
-  name="VFS-Read-Chunk-Size"
-  endinfo="MB"
-  start1="16"
-  end1="1024"
-  note1="
-NOTE2: Must be greater than the buffer-size to prevent too many open file requests!"
+if [[ "$mountselection" == "8" ]]; then
+  name="VFS-Cache-Max-Size"
+  sizeSuffix="GB"
+  start="1"
+  end="1000"
+  note="Only used if vfs-cache-mode is NOT off, impacts how long files are cached on disk. Value is the max total size of objects in the cache."
 fi
-
-if [[ "$mountselection" == "6" ]]; then
-  name="VFS-Read-Chunk-Size-Limit"
-  endinfo="GB"
-  start1="1"
-  end1="100"
-  note1="
-NOTE2: No Info Yet!"
-fi
-
+    
 tee <<-EOF
 
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 Setting Variable >>> $name
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-Type a Number from [$start1] through [$end1] ($endinfo)
+Type a number between [$start] and [$end] ($sizeSuffix)
 
-NOTE1: Read the wiki on how changing these numbers impact the server!
-Nothing takes affect until PGMove/PGBlitz is deployed/redeployed again!
-$note1
+Please read the wiki on how changing these settings impact stability and performance!
+After you change these settings, you must redeploy the mounts for them to take effect.
+
+$note
 
 Quitting? Type >>> exit
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 EOF
-
-read -rp '↘️  Input Selection | Press [ENTER]: ' typed < /dev/tty
-if [[ "$typed" == "exit" || "$typed" == "Exit" || "$typed" == "EXIT" ]]; then mountnumbers; fi
-
-# This Select Requires Answers to be In the Power of Two
-if [[ "$mountselection" == "2" ]]; then
-  if [[ "$typed" != "8" && "$typed" != "16" && "$typed" != "32" && "$typed" != "64" && "$typed" != "128" && "$typed" != "256" && "$typed" != "512" && "$typed" != "1024" ]]; then
+    
+    read -rp '↘️  Input Selection | Press [ENTER]: ' typed < /dev/tty
+    if [[ "$typed" == "exit" || "$typed" == "Exit" || "$typed" == "EXIT" ]]; then mountnumbers; fi
+    
+    # This Select Requires Answers to be In the Power of Two
+    if [[ "$mountselection" == "2" ]]; then
+        if [[ "$typed" != "8" && "$typed" != "16" && "$typed" != "32" && "$typed" != "64" && "$typed" != "128" && "$typed" != "256" && "$typed" != "512" && "$typed" != "1024" ]]; then
 tee <<-EOF
 
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 Power of Two Notice
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-NOTE: Drive-Chunk-Size must set by a power of two!
+NOTE: The value you enter must be a power of two!
 [8] [16] [32] [64] [128] [256] [512] [1024]
 
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 EOF
-  read -rp '↘️  Acknowledge Info | Press [ENTER] ' typed < /dev/tty
-mountset
-fi; fi
+            read -rp '↘️  Acknowledge Info | Press [ENTER] ' typed < /dev/tty
+            mountset
+    fi; fi
+    
+    
+    if [[ "$typed" -lt "$start" || "$typed" -gt "$end" ]]; then mountset; else
+        
+        if [[ "$mountselection" == "1" ]]; then echo "$typed" > /var/plexguide/vfs_bs; fi
+        if [[ "$mountselection" == "2" ]]; then echo "$typed" > /var/plexguide/vfs_dcs; fi
+        if [[ "$mountselection" == "3" ]]; then echo "$typed" > /var/plexguide/vfs_dct; fi
+        if [[ "$mountselection" == "4" ]]; then echo "$typed" > /var/plexguide/vfs_rcs; fi
+        if [[ "$mountselection" == "5" ]]; then echo "$typed" > /var/plexguide/vfs_rcsl; fi
+        if [[ "$mountselection" == "7" ]]; then echo "$typed" > /var/plexguide/vfs_cma; fi
+        if [[ "$mountselection" == "8" ]]; then echo "$typed" > /var/plexguide/vfs_cms; fi
 
 
-if [[ "$typed" -lt "$start1" || "$typed" -gt "$end1" ]]; then mountset; else
+      if [[ "$mountselection" == "6" ]]; then 
+        if [[ "$typed" == "1" ]]; then echo "off" > /var/plexguide/vfs_cm; fi
+        if [[ "$typed" == "2" ]]; then echo "minimal" > /var/plexguide/vfs_cm; fi
+        if [[ "$typed" == "3" ]]; then echo "writes" > /var/plexguide/vfs_cm; fi
+        if [[ "$typed" == "4" ]]; then echo "full" > /var/plexguide/vfs_cm; fi
+      fi
 
-  if [[ "$mountselection" == "1" ]]; then echo "$typed" > /var/plexguide/vfs_bs; fi
-  if [[ "$mountselection" == "2" ]]; then echo "$typed" > /var/plexguide/vfs_dcs; fi
-  if [[ "$mountselection" == "3" ]]; then echo "$typed" > /var/plexguide/vfs_dct; fi
-  if [[ "$mountselection" == "4" ]]; then echo "$typed" > /var/plexguide/vfs_cma; fi
-  if [[ "$mountselection" == "5" ]]; then echo "$typed" > /var/plexguide/vfs_rcs; fi
-  if [[ "$mountselection" == "6" ]]; then echo "$typed" > /var/plexguide/vfs_rcsl; fi
-
-fi
-
-mountnumbers
+    fi
+    
+    mountnumbers
 }

--- a/functions/mountnumbers.sh
+++ b/functions/mountnumbers.sh
@@ -16,14 +16,14 @@ VFS RClone Mount Settings ~ vfs.pgblitz.com
 
 RClone Variable Name           Default ~ Current Settings
 
-[1] Buffer-Size                16        [$vfs_bs] MB
-[2] Drive-Chunk-Size           256        [$vfs_dcs] MB
-[3] Dir-Cache-Time             2         [$vfs_dct] Minutes
-[4] VFS-Read-Chunk-Size        64        [$vfs_rcs] MB
-[5] VFS-Read-Chunk-Size-Limit  2         [$vfs_rcsl] GB
-[6] VFS-Cache-Mode             off       [$vfs_cm]
-[7] VFS-Cache-Max-Age          72        [$vfs_cma] Hours
-[8] VFS-Cache-Max-Size         250        [$vfs_cms] GB
+[1] Buffer-Size                16MB        [$vfs_bs] MB
+[2] Drive-Chunk-Size           256MB       [$vfs_dcs] MB
+[3] Dir-Cache-Time             2M          [$vfs_dct] Minutes
+[4] VFS-Read-Chunk-Size        64MB        [$vfs_rcs] MB
+[5] VFS-Read-Chunk-Size-Limit  2GB         [$vfs_rcsl] GB
+[6] VFS-Cache-Mode             off         [$vfs_cm]
+[7] VFS-Cache-Max-Age          168H        [$vfs_cma] Hours
+[8] VFS-Cache-Max-Size         100GB       [$vfs_cms] GB
 [Z] Exit
 
 note: Visit the URL! Bad settings causes mount performance issues!

--- a/functions/variables.sh
+++ b/functions/variables.sh
@@ -103,7 +103,7 @@ else dversionoutput="None"; fi
   variable /var/plexguide/vfs_bs "16"
   vfs_bs=$(cat /var/plexguide/vfs_bs)
 
-  variable /var/plexguide/vfs_dcs "256"
+  variable /var/plexguide/vfs_dcs "64"
   vfs_dcs=$(cat /var/plexguide/vfs_dcs)
 
   variable /var/plexguide/vfs_dct "2"

--- a/functions/variables.sh
+++ b/functions/variables.sh
@@ -119,10 +119,9 @@ else dversionoutput="None"; fi
   vfs_rcsl=$(cat /var/plexguide/vfs_rcsl)
   
   variable /var/plexguide/vfs_cm "off"
-  vfs_rcsl=$(cat /var/plexguide/vfs_cm)
+  vfs_cm=$(cat /var/plexguide/vfs_cm)
 
   variable /var/plexguide/vfs_cms "100"
-  vfs_rcsl=$(cat /var/plexguide/vfs_cm)
-
+  vfs_cms=$(cat /var/plexguide/vfs_cms)
 
 }

--- a/functions/variables.sh
+++ b/functions/variables.sh
@@ -100,16 +100,16 @@ elif [[ "$dversion" == "le" ]]; then dversionoutput="Local HD/Mount"
 else dversionoutput="None"; fi
 
 # For PG Blitz Mounts
-  variable /var/plexguide/vfs_bs "32"
+  variable /var/plexguide/vfs_bs "16"
   vfs_bs=$(cat /var/plexguide/vfs_bs)
 
-  variable /var/plexguide/vfs_dcs "32"
+  variable /var/plexguide/vfs_dcs "256"
   vfs_dcs=$(cat /var/plexguide/vfs_dcs)
 
   variable /var/plexguide/vfs_dct "2"
   vfs_dct=$(cat /var/plexguide/vfs_dct)
 
-  variable /var/plexguide/vfs_cma "72"
+  variable /var/plexguide/vfs_cma "168"
   vfs_cma=$(cat /var/plexguide/vfs_cma)
 
   variable /var/plexguide/vfs_rcs "64"
@@ -117,5 +117,12 @@ else dversionoutput="None"; fi
 
   variable /var/plexguide/vfs_rcsl "2"
   vfs_rcsl=$(cat /var/plexguide/vfs_rcsl)
+  
+  variable /var/plexguide/vfs_cm "off"
+  vfs_rcsl=$(cat /var/plexguide/vfs_cm)
+
+  variable /var/plexguide/vfs_cms "100"
+  vfs_rcsl=$(cat /var/plexguide/vfs_cm)
+
 
 }


### PR DESCRIPTION
Added more/ better notes and defaults.

BTW vfs-cache settings have had 0 effect and thus only currently affected gcrypt mounts.

This PR changes it so the cache mode is shared on all mounts.

Currently cache mode is set to write on the crypt mounts, that change was made a few months ago due to a user bug report, however prior to that change it used to be off for crypt mounts. It's always been off for unencrypted mounts.

This PR changes the existing behavior, this is reverting the crypt mounts to have cache mode off again, which should be fine for most people. I only enabled write in the first place was because of a user report where the error would be resolved by changing the cache mode, however that user may have been doing things outside of normal operations. Regardless, it should be tested with cache mode off when using encrypt.

if there is a problem where you want crypt mount to have a different cache mode than the unencrypt mount. I could add a 2nd cache mode setting, but perhaps it would be better to check if encrypt is used, then default to "write" instead. Are tdrive and tcrypt are used at the same time if using encrypted?