### PR TITLE
missing '\' in pgblitz.sh and pgmove.sh

### DIFF
--- a/scripts/pgblitz.sh
+++ b/scripts/pgblitz.sh
@@ -55,7 +55,7 @@ while read p; do
   --transfers=16 \
   --bwlimit {{bandwidth.stdout}}M \
   --max-size=300G \
-  --useragent="$useragent"
+  --useragent="$useragent" \
   --drive-chunk-size={{vfs_dcs}}M \
   --exclude="**_HIDDEN~" --exclude=".unionfs/**" \
   --exclude='**partial~' --exclude=".unionfs-fuse/**" \

--- a/scripts/pgmove.sh
+++ b/scripts/pgmove.sh
@@ -58,7 +58,7 @@ rclone move "{{hdpath}}/move/" "{{type}}:/" \
 --checkers=16 \
 --max-size=300G \
 --drive-chunk-size={{vfs_dcs}}M \
---user-agent="$useragent"
+--user-agent="$useragent" \
 --exclude="**_HIDDEN~" --exclude=".unionfs/**" \
 --exclude='**partial~' --exclude=".unionfs-fuse/**" \
 --exclude=".fuse_hidden**" \


### PR DESCRIPTION
fixed missing \ in pgblitz.sh and pgmove.sh