### PR TITLE
Swapping bw limit values

### DIFF
--- a/source/transfer.sh
+++ b/source/transfer.sh
@@ -19,8 +19,8 @@ touch /pg/logs/.temp_list
 
 basicpath="$(cat /pg/var/server.hd.path)"
 useragent="$(cat /pg/var/uagent)"
-bwg="$(cat /pg/var/blitz.bw)"
-bws="$(cat /pg/var/move.bw)"
+bwg="$(cat /pg/var/move.bw)"
+bws="$(cat /pg/var/blitz.bw)"
 
 var3=$(cat /pg/rclone/deployed.version)
 if [[ "$var3" == "gd" ]]; then var4="gdrive"


### PR DESCRIPTION
I based my decisions here off of this bit of code from clonestartoutput.sh:
``` 
# pull throttle speeds based on role
if [[ "$transport" == "gd" || "$transport" == "gc" ]]; then
throttle=$(cat /pg/var/move.bw)
output1="[C] Transport Select"
else
throttle=$(cat /pg/var/blitz.bw)
output1="[C] Options"
fi 
```

Using this I came to the following conclusion:
gdrive should use move service
sdrive should use blitz service

If my assumption is correct here then the bw limits were the wrong way around in transfer.sh. I have swapped them, re-deployed my mounts and tested moving files in to my SD and found bandwidth to be working as expected. 

Requires testing from gdrive user.